### PR TITLE
fix: repair PNG and PDF export

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -441,12 +441,19 @@ export default function RationGeneratorUZ() {
     const exportPNG = async () => {
         if (!exportRef.current) return;
         try {
-            const htmlToImage = await import("html-to-image");
-            const dataUrl: string = await htmlToImage.toPng(exportRef.current, { cacheBust: true, backgroundColor: "#ffffff", pixelRatio: 2 });
-            const a = document.createElement("a");
-            a.href = dataUrl;
-            a.download = `ratsion_${new Date().toISOString().slice(0, 10)}.png`;
-            a.click();
+            // "html-to-image" CommonJS modulini dinamik import qilish
+            const { toPng } = await import("html-to-image");
+            const dataUrl = await toPng(exportRef.current, {
+                cacheBust: true,
+                backgroundColor: "#ffffff",
+                pixelRatio: 2,
+            });
+            const link = document.createElement("a");
+            link.href = dataUrl;
+            link.download = `ratsion_${new Date().toISOString().slice(0, 10)}.png`;
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
         } catch {
             alert("PNG eksport uchun 'html-to-image' paketini o‘rnating: npm i html-to-image");
         }
@@ -455,13 +462,17 @@ export default function RationGeneratorUZ() {
     const exportPDF = async () => {
         if (!exportRef.current) return;
         try {
-            const htmlToImage = await import("html-to-image");
+            const { toPng } = await import("html-to-image");
             const { jsPDF } = await import("jspdf");
-            const dataUrl: string = await htmlToImage.toPng(exportRef.current, { cacheBust: true, backgroundColor: "#ffffff", pixelRatio: 2 });
+            const dataUrl = await toPng(exportRef.current, {
+                cacheBust: true,
+                backgroundColor: "#ffffff",
+                pixelRatio: 2,
+            });
             const pdf = new jsPDF({ orientation: "p", unit: "pt", format: "a4" });
             const img = new Image();
             img.src = dataUrl;
-            await new Promise((res) => (img.onload = res));
+            await new Promise(res => (img.onload = res));
             const pw = pdf.internal.pageSize.getWidth();
             const ph = pdf.internal.pageSize.getHeight();
             const ratio = Math.min(pw / img.width, ph / img.height);


### PR DESCRIPTION
## Summary
- fix PNG/PDF export by using proper dynamic imports for `html-to-image`
- append download links to DOM and clean up after click
- refactor PDF export to match new PNG helper

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6897d935b53883338e13554600dc63d5